### PR TITLE
Update HTTP status code handling for Sia v1.0

### DIFF
--- a/network.go
+++ b/network.go
@@ -80,7 +80,7 @@ func (sc *SiadClient) SubmitHeader(header []byte) (err error) {
 		return
 	}
 	switch resp.StatusCode {
-	case 200:
+	case 204:
 	default:
 		err = fmt.Errorf("Invalid siad response, status code %d", resp.StatusCode)
 		return


### PR DESCRIPTION
The default HTTP success status codes changed in NebulousLabs/Sia#1249 which will be in the upcoming Sia v1.0 release.

Success responses with no returned data are now returned as 204 No Content instead of 200 OK.