### PR TITLE
Submit solutions in a separate goroutine

### DIFF
--- a/miner.go
+++ b/miner.go
@@ -127,9 +127,11 @@ func (miner *Miner) mine() {
 			for i := 0; i < 8; i++ {
 				header[i+32] = nonceOut[i]
 			}
-			if err = miner.siad.SubmitHeader(header); err != nil {
-				log.Println(miner.minerID, "- Error submitting block -", err)
-			}
+			go func() {
+				if err := miner.siad.SubmitHeader(header); err != nil {
+					log.Println(miner.minerID, "- Error submitting block -", err)
+				}
+			}()
 			log.Println("Work header:", work.Header)
 			log.Println("Offset:", work.Offset)
 			log.Println("Submitted header:", header)

--- a/miner.go
+++ b/miner.go
@@ -118,9 +118,9 @@ func (miner *Miner) mine() {
 		}
 		//Check if match found
 		if nonceOut[0] != 0 || nonceOut[1] != 0 || nonceOut[2] != 0 || nonceOut[3] != 0 || nonceOut[4] != 0 || nonceOut[5] != 0 || nonceOut[6] != 0 || nonceOut[7] != 0 {
-			log.Println(miner.minerID, "-", "Yay, block found!")
+			log.Println(miner.minerID, "-", "Yay, solution found!")
 			if nonceOut[0] == 0 {
-				log.Println(miner.minerID, "-", "Block found with a nonce that started with 0...")
+				log.Println(miner.minerID, "-", "Solution found with a nonce that started with 0...")
 			}
 			// Copy nonce to a new header.
 			header := append([]byte(nil), work.Header...)
@@ -129,7 +129,7 @@ func (miner *Miner) mine() {
 			}
 			go func() {
 				if err := miner.siad.SubmitHeader(header); err != nil {
-					log.Println(miner.minerID, "- Error submitting block -", err)
+					log.Println(miner.minerID, "- Error submitting solution -", err)
 				}
 			}()
 			log.Println("Work header:", work.Header)


### PR DESCRIPTION
The goal is to avoid GPU idle time due to network calls. This is important in the case of pooled mining, as shares may need to be submitted every few seconds.